### PR TITLE
logcheck: Add log linter

### DIFF
--- a/cmd/loglint/main.go
+++ b/cmd/loglint/main.go
@@ -1,0 +1,33 @@
+// MIT License
+//
+// Copyright (c) 2020 Oncilla
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package main
+
+import (
+	"golang.org/x/tools/go/analysis/singlechecker"
+
+	"github.com/oncilla/gochecks/logcheck"
+)
+
+func main() {
+	singlechecker.Main(logcheck.Analyzer)
+}

--- a/logcheck/BUILD.bazel
+++ b/logcheck/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_tool_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["logcheck.go"],
+    importpath = "github.com/oncilla/gochecks/logcheck",
+    visibility = ["//visibility:public"],
+    deps = ["@org_golang_x_tools//go/analysis:go_tool_library"],
+)
+
+go_tool_library(
+    name = "go_tool_library",
+    srcs = ["logcheck.go"],
+    importpath = "github.com/oncilla/gochecks/logcheck",
+    visibility = ["//visibility:public"],
+    deps = ["@org_golang_x_tools//go/analysis:go_tool_library"],
+)

--- a/logcheck/logcheck.go
+++ b/logcheck/logcheck.go
@@ -1,0 +1,173 @@
+// MIT License
+//
+// Copyright (c) 2020 Oncilla
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package logcheck
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/printer"
+	"go/token"
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// Analyzer checks all calls on the log package.
+var Analyzer = &analysis.Analyzer{
+	Name:             "logcheck",
+	Doc:              "reports invalid log calls",
+	Run:              run,
+	RunDespiteErrors: true,
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	for _, file := range pass.Files {
+		tgtPkg := findPkgName(file)
+		if tgtPkg == "" {
+			continue
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			ce, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			se, ok := ce.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			if !isTarget(se, tgtPkg) {
+				return true
+			}
+			var varargs []ast.Expr
+			switch se.Sel.Name {
+			case "Trace", "Debug", "Info", "Warn", "Error", "Crit":
+				if len(ce.Args) < 2 {
+					return true
+				}
+				varargs = ce.Args[1:]
+			}
+			// We cannot check if varargs with ellipsis.
+			if ce.Ellipsis != token.NoPos {
+				return true
+			}
+			if len(varargs)%2 != 0 {
+				pass.Reportf(varargs[0].Pos(), "context should be even: len=%d ctx=%s expr=%q",
+					len(varargs), renderCtx(pass.Fset, varargs), render(pass.Fset, ce))
+			}
+			for i := 0; i < len(varargs); i += 2 {
+				lit := varargs[i]
+				if !isString(pass, lit) {
+					pass.Reportf(lit.Pos(), "key should be string: type=%q name=%q expr=%q",
+						pass.TypesInfo.TypeOf(lit), render(pass.Fset, lit), render(pass.Fset, ce))
+				}
+			}
+			return true
+		})
+	}
+	return nil, nil
+}
+
+func isTarget(se *ast.SelectorExpr, tgtPkg string) bool {
+	switch x := se.X.(type) {
+	case *ast.Ident:
+		if x.Name == tgtPkg && x.Obj == nil {
+			return true
+		}
+		if x.Obj == nil {
+			return false
+		}
+		decl, ok := x.Obj.Decl.(*ast.AssignStmt)
+		if !ok {
+			return false
+		}
+		for _, data := range decl.Rhs {
+			if loggerConstructor(data, tgtPkg) {
+				return true
+			}
+		}
+		return false
+	case *ast.CallExpr:
+		return loggerConstructor(x, tgtPkg)
+	default:
+		return false
+	}
+}
+
+func loggerConstructor(exp ast.Expr, tgtPkg string) bool {
+	ce, ok := exp.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	se, ok := ce.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	id, ok := se.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	if id.Name != tgtPkg {
+		return false
+	}
+	switch se.Sel.Name {
+	case "FromCtx", "New", "Root":
+		return true
+	}
+	return false
+}
+
+func findPkgName(file *ast.File) string {
+	var tgtPkg string
+	for _, imp := range file.Imports {
+		if imp.Path.Value == `"github.com/scionproto/scion/go/lib/log"` {
+			tgtPkg = "log"
+			if imp.Name != nil {
+				tgtPkg = imp.Name.Name
+			}
+		}
+	}
+	return tgtPkg
+}
+
+func isString(pass *analysis.Pass, lit ast.Expr) bool {
+	t, ok := pass.TypesInfo.TypeOf(lit).Underlying().(*types.Basic)
+	return ok && t.Info()&types.IsString != 0
+}
+
+func renderCtx(fset *token.FileSet, varargs []ast.Expr) string {
+	var p []string
+	for _, arg := range varargs {
+		p = append(p, render(fset, arg))
+	}
+	return fmt.Sprintf("[%s]", strings.Join(p, ","))
+}
+
+func render(fset *token.FileSet, x interface{}) string {
+	var buf bytes.Buffer
+	if err := printer.Fprint(&buf, fset, x); err != nil {
+		panic(err)
+	}
+	return buf.String()
+}

--- a/logcheck/logcheck_test.go
+++ b/logcheck/logcheck_test.go
@@ -1,0 +1,41 @@
+// MIT License
+//
+// Copyright (c) 2020 Oncilla
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package logcheck_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+
+	"github.com/oncilla/gochecks/logcheck"
+)
+
+func Test(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, logcheck.Analyzer, "fail")
+}
+
+func TestNamed(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, logcheck.Analyzer, "named")
+}

--- a/logcheck/testdata/src/fail/fail.go
+++ b/logcheck/testdata/src/fail/fail.go
@@ -1,0 +1,107 @@
+// MIT License
+//
+// Copyright (c) 2019 Oncilla
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package fail
+
+import (
+	"context"
+
+	"github.com/scionproto/scion/go/lib/log"
+)
+
+const (
+	untyped     = "untyped_key"
+	typed   key = "typed_key"
+)
+
+var value = 1
+
+func validParity() {
+	log.Trace("message")
+	log.Debug("message")
+	log.Info("message")
+	log.Warn("message")
+	log.Error("message")
+	log.Crit("message")
+
+	log.Trace("message")
+	log.Debug("message")
+	log.Info("message")
+	log.Warn("message")
+	log.Error("message")
+	log.Crit("message")
+
+	log.Trace("message", "key", value)
+	log.Debug("message", "key", value)
+	log.Info("message", "key", value)
+	log.Warn("message", "key", value)
+	log.Error("message", "key", value)
+	log.Crit("message", "key", value)
+
+	log.Trace("message", "key", value, "key", value)
+	log.Debug("message", "key", value, "key", value)
+	log.Info("message", "key", value, "key", value)
+	log.Warn("message", "key", value, "key", value)
+	log.Error("message", "key", value, "key", value)
+	log.Crit("message", "key", value, "key", value)
+}
+
+func validTypes() {
+	log.Debug("message", "key", value)
+	log.Debug("message", untyped, value)
+	log.Debug("message", typed, value)
+}
+
+func invalidParity() {
+	log.Trace("message", "key") // want `context should be even: len=1 ctx=\["key"\]`
+	log.Debug("message", "key") // want `context should be even: len=1 ctx=\["key"\]`
+	log.Info("message", "key")  // want `context should be even: len=1 ctx=\["key"\]`
+	log.Warn("message", "key")  // want `context should be even: len=1 ctx=\["key"\]`
+	log.Error("message", "key") // want `context should be even: len=1 ctx=\["key"\]`
+	log.Crit("message", "key")  // want `context should be even: len=1 ctx=\["key"\]`
+
+	log.Trace("message", "key", value, "key") // want `context should be even: len=3 ctx=\["key",value,"key"\]`
+	log.Debug("message", "key", value, "key") // want `context should be even: len=3 ctx=\["key",value,"key"\]`
+	log.Info("message", "key", value, "key")  // want `context should be even: len=3 ctx=\["key",value,"key"\]`
+	log.Warn("message", "key", value, "key")  // want `context should be even: len=3 ctx=\["key",value,"key"\]`
+	log.Error("message", "key", value, "key") // want `context should be even: len=3 ctx=\["key",value,"key"\]`
+	log.Crit("message", "key", value, "key")  // want `context should be even: len=3 ctx=\["key",value,"key"\]`
+}
+
+func invalidType() {
+	log.Info("message", value, value) // want `key should be string: type="int" name="value"`
+}
+
+func logger() {
+	logger := log.FromCtx(context.Background())
+	loggerN := log.New()
+	loggerR := log.Root()
+	logger.Info("message", "key")  // want `context should be even: len=1 ctx=\["key"\]`
+	loggerN.Info("message", "key") // want `context should be even: len=1 ctx=\["key"\]`
+	loggerR.Info("message", "key") // want `context should be even: len=1 ctx=\["key"\]`
+
+	log.FromCtx(context.Background()).Info("message", "key") // want `context should be even: len=1 ctx=\["key"\]`
+	log.New().Info("message", "key")                         // want `context should be even: len=1 ctx=\["key"\]`
+	log.Root().Info("message", "key")                        // want `context should be even: len=1 ctx=\["key"\]`
+}
+
+type key string

--- a/logcheck/testdata/src/named/named.go
+++ b/logcheck/testdata/src/named/named.go
@@ -1,0 +1,43 @@
+// MIT License
+//
+// Copyright (c) 2020 Oncilla
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package named
+
+import (
+	log "fake/lib/slog"
+
+	slog "github.com/scionproto/scion/go/lib/log"
+)
+
+func fakeImportIgnored() {
+	log.Debug("message", nil)
+	log.Info("message", "a")
+	log.Warn("message", "b")
+	log.Error("messsage", nil)
+}
+
+func valid() {
+	slog.Debug("message", "key")  // want `context should be even: len=1 ctx=\["key"\]`
+	slog.Info("message", "key")   // want `context should be even: len=1 ctx=\["key"\]`
+	slog.Warn("message", "key")   // want `context should be even: len=1 ctx=\["key"\]`
+	slog.Error("messsage", "key") // want `context should be even: len=1 ctx=\["key"\]`
+}


### PR DESCRIPTION
This linter checks that the logger has an even amount of logging context
and that all keys are of string type.